### PR TITLE
Fix username parameter in GitHub profile views counter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - 🔭 I’m currently working on C++, PHP, Java, Javascript, CSS and HTML5 Development, Linux
 - 🌱 I’m currently learning Tauri, Rust, Node.js, React, Electron, Solid.js, Docker
 
-![](https://komarev.com/ghpvc/?username=your-github-username&color=green)
+![](https://komarev.com/ghpvc/?username=filippo-bilardo&color=green)
 
 <!--
 **filippo-bilardo/filippo-bilardo** is a ✨ _special_ ✨ repository because its `README.md` (this file) appears on your GitHub profile.


### PR DESCRIPTION
This pull request fixes the broken username parameter in the GitHub profile views counter URL in the `README.md` file.

#### Changes Made:
- Replaced the placeholder `your-github-username` in the URL with the correct username (`filippo-bilardo`).

#### Reason for the change:
The previous URL was pointing to an incorrect or placeholder username, causing the profile views counter to not work as intended. This update ensures the counter works properly for this specific username (`filippo-bilardo`).